### PR TITLE
Fix actions/cache step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
           path: |
             ~/.cache/org.swift.swiftpm
             .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-swift-${{ matrix.swift }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-swift-${{ matrix.swift }}-spm-
 
       - name: Build
         run: swift build -v


### PR DESCRIPTION
Tests are failing with `error: module compiled with Swift 6.2 cannot be imported by the Swift 6.1 compiler`. I suspect it has something to do with the CI workflow reusing a cache created by a different version of Swift.