### PR TITLE
Demonstrate API compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ All you need to do is change your import statement:
 ```diff
 - import FoundationModels
 + import AnyLanguageModel
+```
 
+```swift
 struct WeatherTool: Tool {
     let name = "getWeather"
     let description = "Retrieve the latest weather information for a city"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ let model = SystemLanguageModel.default
 let session = LanguageModelSession(model: model, tools: [WeatherTool()])
 
 let response = try await session.respond {
-    Prompt("What's the weather in Cupertino?")
+    Prompt("How's the weather in Cupertino?")
 }
 print(response.content)
 ```
@@ -130,7 +130,7 @@ models.append(LlamaLanguageModel(modelPath: "/path/to/model.gguf"))
 
 for model in models {
     let session = LanguageModelSession(model: model, tools: [WeatherTool()])
-    let response = try await session.respond(to: "What's the weather in Cupertino?")
+    let response = try await session.respond(to: "How's the weather in Cupertino?")
     print(response.text) // "It's sunny and 72°F in Cupertino"
 }
 ```

--- a/Tests/AnyLanguageModelTests/APICompatibilityAnyLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/APICompatibilityAnyLanguageModelTests.swift
@@ -1,0 +1,31 @@
+import Testing
+
+#if canImport(FoundationModels)
+    import AnyLanguageModel
+
+    @available(macOS 26.0, *)
+    @Test("AnyLanguageModel Drop-In Compatibility", .enabled(if: SystemLanguageModel.default.isAvailable))
+    func anyLanguageModelCompatibility() async throws {
+        let model = SystemLanguageModel.default
+        let session = LanguageModelSession(
+            model: model,
+            instructions: Instructions("You are a helpful assistant.")
+        )
+
+        let options = GenerationOptions(temperature: 0.7)
+        let response = try await session.respond(options: options) {
+            Prompt("Say 'Hello'")
+        }
+        #expect(!response.content.isEmpty)
+
+        let stream = session.streamResponse {
+            Prompt("Count to 3")
+        }
+        var hasSnapshots = false
+        for try await _ in stream {
+            hasSnapshots = true
+            break
+        }
+        #expect(hasSnapshots)
+    }
+#endif

--- a/Tests/AnyLanguageModelTests/APICompatibilityFoundationModelsTests.swift
+++ b/Tests/AnyLanguageModelTests/APICompatibilityFoundationModelsTests.swift
@@ -1,0 +1,31 @@
+import Testing
+
+#if canImport(FoundationModels)
+    import FoundationModels
+
+    @available(macOS 26.0, *)
+    @Test("FoundationModels Drop-In Compatibility", .enabled(if: SystemLanguageModel.default.isAvailable))
+    func foundationModelsCompatibility() async throws {
+        let model = SystemLanguageModel.default
+        let session = LanguageModelSession(
+            model: model,
+            instructions: Instructions("You are a helpful assistant.")
+        )
+
+        let options = GenerationOptions(temperature: 0.7)
+        let response = try await session.respond(options: options) {
+            Prompt("Say 'Hello'")
+        }
+        #expect(!response.content.isEmpty)
+
+        let stream = session.streamResponse {
+            Prompt("Count to 3")
+        }
+        var hasSnapshots = false
+        for try await _ in stream {
+            hasSnapshots = true
+            break
+        }
+        #expect(hasSnapshots)
+    }
+#endif

--- a/Tests/AnyLanguageModelTests/AnthropicLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/AnthropicLanguageModelTests.swift
@@ -90,7 +90,7 @@ struct AnthropicLanguageModelTests {
         let weatherTool = WeatherTool()
         let session = LanguageModelSession(model: model, tools: [weatherTool])
 
-        let response = try await session.respond(to: "What's the weather in San Francisco?")
+        let response = try await session.respond(to: "How's the weather in San Francisco?")
 
         var foundToolOutput = false
         for case let .toolOutput(toolOutput) in response.transcriptEntries {

--- a/Tests/AnyLanguageModelTests/MLXLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/MLXLanguageModelTests.swift
@@ -64,7 +64,7 @@ import Testing
                 instructions: "You are a helpful assistant. Use available tools when needed."
             )
 
-            let response = try await session.respond(to: "What's the weather in San Francisco?")
+            let response = try await session.respond(to: "How's the weather in San Francisco?")
 
             var foundToolOutput = false
             for case let .toolOutput(toolOutput) in response.transcriptEntries {

--- a/Tests/AnyLanguageModelTests/OllamaLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/OllamaLanguageModelTests.swift
@@ -85,7 +85,7 @@ struct OllamaLanguageModelTests {
         let weatherTool = spy(on: WeatherTool())
         let session = LanguageModelSession(model: model, tools: [weatherTool])
 
-        let response = try await session.respond(to: "What's the weather in San Francisco?")
+        let response = try await session.respond(to: "How's the weather in San Francisco?")
 
         var foundToolOutput = false
         for case let .toolOutput(toolOutput) in response.transcriptEntries {

--- a/Tests/AnyLanguageModelTests/OpenAILanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/OpenAILanguageModelTests.swift
@@ -104,7 +104,7 @@ struct OpenAILanguageModelTests {
             let weatherTool = WeatherTool()
             let session = LanguageModelSession(model: model, tools: [weatherTool])
 
-            let response = try await session.respond(to: "What's the weather in San Francisco?")
+            let response = try await session.respond(to: "How's the weather in San Francisco?")
 
             var foundToolOutput = false
             for case let .toolOutput(toolOutput) in response.transcriptEntries {
@@ -196,7 +196,7 @@ struct OpenAILanguageModelTests {
             let weatherTool = WeatherTool()
             let session = LanguageModelSession(model: model, tools: [weatherTool])
 
-            let response = try await session.respond(to: "What's the weather in San Francisco?")
+            let response = try await session.respond(to: "How's the weather in San Francisco?")
 
             var foundToolOutput = false
             for case let .toolOutput(toolOutput) in response.transcriptEntries {


### PR DESCRIPTION
This PR updates the README to show how you can switch from the Foundation Models framework to AnyLanguageModel just by changing the `import` statement. It also adds test coverage to verify this.