### PR TITLE
Include instructions param in OpenAILanguageModel

### DIFF
--- a/Sources/AnyLanguageModel/Models/OpenAILanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/OpenAILanguageModel.swift
@@ -450,7 +450,7 @@ private enum Responses {
             "stream": .bool(stream),
         ]
 
-        if case .text(let instructions) = systemMessage?.content, !instructions.isEmpty {
+        if case .text(let instructions) = systemMessage?.content {
             body["instructions"] = .string(instructions)
         }
 


### PR DESCRIPTION
This PR updates `OpenAILanguageModel` to include the `LanguageModelSession.instructions` parameter in requests when provided.

- For the Responses API, `instructions` is appended to the body as `instructions` ([docs](https://platform.openai.com/docs/api-reference/responses/create#responses_create-instructions)).
- For the Chat Completions API, `instructions` is appended to the messages array with the `system` tag. (Note: [the docs](https://platform.openai.com/docs/api-reference/chat/create#chat_create-messages-developer_message) say that `developer` is preferred over `system`, but it's presumably backwards compatible).

If disregarding `instructions` was the intended behavior, feel free to close this PR.