### PR TITLE
Update mlx-swift-examples repository to mlx-swift-lm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/mattt/JSONSchema.git", from: "1.3.0"),
         .package(url: "https://github.com/mattt/EventSource.git", from: "1.3.0"),
         .package(url: "https://github.com/mattt/PartialJSONDecoder.git", from: "1.0.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-examples/", branch: "main"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm/", branch: "main"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.0.0"),
         .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "1.6818.0")),
     ],
@@ -46,17 +46,17 @@ let package = Package(
                 .product(name: "PartialJSONDecoder", package: "PartialJSONDecoder"),
                 .product(
                     name: "MLXLLM",
-                    package: "mlx-swift-examples",
+                    package: "mlx-swift-lm",
                     condition: .when(traits: ["MLX"])
                 ),
                 .product(
                     name: "MLXVLM",
-                    package: "mlx-swift-examples",
+                    package: "mlx-swift-lm",
                     condition: .when(traits: ["MLX"])
                 ),
                 .product(
                     name: "MLXLMCommon",
-                    package: "mlx-swift-examples",
+                    package: "mlx-swift-lm",
                     condition: .when(traits: ["MLX"])
                 ),
                 .product(

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This results in smaller binary sizes and faster build times.
 - `CoreML`: Enables Core ML model support
   (depends on `huggingface/swift-transformers`)
 - `MLX`: Enables MLX model support
-  (depends on `ml-explore/mlx-swift-examples`)
+  (depends on `ml-explore/mlx-swift-lm`)
 - `Llama`: Enables llama.cpp support
   (requires `mattt/llama.swift`)
 


### PR DESCRIPTION
mlx-swift-examples has been moved to mlx-swift-lm.
Update dependency URL to reflect the new location.