### PR TITLE
Fix package dependency declarations in package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/mattt/JSONSchema", from: "1.3.0"),
         .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "1.6818.0")),
         .package(url: "https://github.com/mattt/PartialJSONDecoder", from: "1.0.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "2.0.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", branch: "main"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Follow-up to #30 

Attempting to resolve dependencies in an app, Xcode is reporting this error:

> exhausted attempts to resolve the dependencies graph, with the following dependencies unresolved:
> * 'mlx-swift-lm' from https://github.com/ml-explore/mlx-swift-lm/

This PR drops the trailing slash, which I don't recall being a problem before, but is the only reason I can think of for this not working as expected. 

This PR also takes this opportunity to drop `.git` suffixes from dependency declarations and sort them ~lexicographically~ by owner.