### PR TITLE
expose HubApi and model directory configuration for MLX

### DIFF
--- a/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
@@ -66,8 +66,10 @@ import Foundation
             let context: ModelContext
             if let directory {
                 context = try await loadModel(directory: directory)
+            } else if let hub {
+                context = try await loadModel(hub: hub, id: modelId)
             } else {
-                context = try await loadModel(hub: hub ?? HubApi(), id: modelId)
+                context = try await loadModel(id: modelId)
             }
 
             // Convert session tools to MLX ToolSpec format


### PR DESCRIPTION
HubApi provides additional configurations such as download directory, something like this:

```
    let modelsDirectory = DirectoryPickerService.modelsDirectory()
    let hub = HubApi(downloadBase: modelsDirectory)
    
    return MLXLanguageModel(modelId: modelId, hub: hub)
 ```

It should be backwards compatible and shouldn't break existing API.