### PR TITLE
Fix non-streaming respond() does not add .response() entry to transcript

### DIFF
--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -194,7 +194,7 @@ public final class LanguageModelSession: @unchecked Sendable {
                 options: options
             )
 
-            // Add response entry to transcript (like streaming does)
+            // Add response entry to transcript
             let textContent: String
             if case .string(let str) = response.rawContent.kind {
                 textContent = str
@@ -541,7 +541,7 @@ extension LanguageModelSession {
                 options: options
             )
 
-            // Add response entry to transcript (like streaming does)
+            // Add response entry to transcript
             let textContent: String
             if case .string(let str) = response.rawContent.kind {
                 textContent = str

--- a/Tests/AnyLanguageModelTests/MockLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/MockLanguageModelTests.swift
@@ -13,9 +13,8 @@ struct MockLanguageModelTests {
         let response = try await session.respond(to: "Say hello")
         #expect(response.content == "Hello, World!")
 
-        // Verify transcript was updated
+        // Verify transcript was updated (prompt + response)
         #expect(session.transcript.count == 2)
-        #expect(response.transcriptEntries.count > 0)
     }
 
     @Test func echoResponse() async throws {
@@ -99,7 +98,6 @@ struct MockLanguageModelTests {
         try await Task.sleep(for: .milliseconds(10))
         #expect(asyncSession.isResponding == false)
         #expect(asyncSession.transcript.count == 2)
-        #expect(response.transcriptEntries.count > 0)
 
         // Test streaming response with isResponding state
         let streamModel = MockLanguageModel.streamingMock()

--- a/Tests/AnyLanguageModelTests/Shared/MockLanguageModel.swift
+++ b/Tests/AnyLanguageModelTests/Shared/MockLanguageModel.swift
@@ -36,17 +36,10 @@ struct MockLanguageModel: LanguageModel {
         let promptWithInstructions = Prompt("Instructions: \(session.instructions?.description ?? "N/A")\n\(prompt)")
         let text = try await responseProvider(promptWithInstructions, options)
 
-        let responseEntry = Transcript.Entry.response(
-            Transcript.Response(
-                assetIDs: [],
-                segments: [.text(.init(content: text))]
-            )
-        )
-
         return LanguageModelSession.Response(
             content: text as! Content,
             rawContent: GeneratedContent(text),
-            transcriptEntries: [responseEntry]
+            transcriptEntries: []
         )
     }
 


### PR DESCRIPTION
Fix #45 