### PR TITLE
Fix missing iOS availability annotations in SystemLanguageModel extensions

### DIFF
--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -317,7 +317,7 @@
         }
     }
 
-    @available(macOS 26.0, *)
+    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension FoundationModels.GenerationSchema {
         internal init(_ content: AnyLanguageModel.GenerationSchema) {
             let resolvedSchema = content.withResolvedRoot() ?? content
@@ -344,21 +344,21 @@
         }
     }
 
-    @available(macOS 26.0, *)
+    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension FoundationModels.GeneratedContent {
         internal init(_ content: AnyLanguageModel.GeneratedContent) throws {
             try self.init(json: content.jsonString)
         }
     }
 
-    @available(macOS 26.0, *)
+    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension AnyLanguageModel.GeneratedContent {
         internal init(_ content: FoundationModels.GeneratedContent) throws {
             try self.init(json: content.jsonString)
         }
     }
 
-    @available(macOS 26.0, *)
+    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension Tool {
         fileprivate func callFunction(arguments: FoundationModels.GeneratedContent) async throws
             -> any PromptRepresentable


### PR DESCRIPTION
## Summary

Several `@available` annotations in `SystemLanguageModel.swift` only specified `macOS 26.0, *` but were missing `iOS 26.0` and other platforms. This causes build failures when targeting iOS 26.0 because the extensions use iOS 26-only APIs (`GenerationSchema`, `GeneratedContent`) but are marked available on all iOS versions due to the `*` wildcard.

## Changes

Fixed 4 `@available` annotations (lines 320, 347, 354, 361) to include all platforms:

```diff
- @available(macOS 26.0, *)
+ @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
```

This matches the pattern used elsewhere in the file (e.g., line 371).

## Error Fixed

```
error: 'GenerationSchema' is only available in iOS 26.0 or newer
error: 'GeneratedContent' is only available in iOS 26.0 or newer
```

## Related

This may be related to issue #15.