### PR TITLE
Fix mlx-swift-lm dependency to use semantic versioning

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "268e14d0644cbc22fdd80ecba0d8aef0cf7a4fcaa635e7ea46197cf462ba5b6b",
+  "originHash" : "e05268408778ca0a95c744c8471c1c10d8373df262dd9a5bf349b4e4d7eefc31",
   "pins" : [
     {
       "identity" : "eventsource",

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
         .package(url: "https://github.com/mattt/JSONSchema", from: "1.3.0"),
         .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "2.7484.0")),
         .package(url: "https://github.com/mattt/PartialJSONDecoder", from: "1.0.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "2.29.3"),
+        // mlx-swift-lm must be >= 2.25.5 for ToolSpec/tool calls and UserInput(chat:processing:tools:).
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "2.25.5"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
     ],
     targets: [


### PR DESCRIPTION
## Summary
- Replace `branch: "main"` with `from: "2.29.3"` for mlx-swift-lm dependency

## Problem
When consumers try to use AnyLanguageModel with semantic versioning:
```swift
.package(url: "...", from: "0.5.3")
```

SPM fails to resolve dependencies because `branch: "main"` is incompatible with version-based transitive dependency resolution:

```
error: exhausted attempts to resolve the dependencies graph, with the following dependencies unresolved:
* 'mlx-swift-lm' from https://github.com/ml-explore/mlx-swift-lm
```

## Solution
Pin mlx-swift-lm to version `2.29.3` (latest stable release) instead of tracking the `main` branch.

## Test plan
- [x] `swift package resolve` succeeds
- [x] `swift build` succeeds