### PR TITLE
Fix running tests on macOS 15

### DIFF
--- a/Tests/AnyLanguageModelTests/APICompatibilityAnyLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/APICompatibilityAnyLanguageModelTests.swift
@@ -3,8 +3,15 @@ import Testing
 #if canImport(FoundationModels)
     import AnyLanguageModel
 
+    private let isSystemLanguageModelAvailable: Bool = {
+        if #available(macOS 26.0, *) {
+            return SystemLanguageModel.default.isAvailable
+        }
+        return false
+    }()
+
     @available(macOS 26.0, *)
-    @Test("AnyLanguageModel Drop-In Compatibility", .enabled(if: SystemLanguageModel.default.isAvailable))
+    @Test("AnyLanguageModel Drop-In Compatibility", .enabled(if: isSystemLanguageModelAvailable))
     func anyLanguageModelCompatibility() async throws {
         let model = SystemLanguageModel.default
         let session = LanguageModelSession(

--- a/Tests/AnyLanguageModelTests/APICompatibilityFoundationModelsTests.swift
+++ b/Tests/AnyLanguageModelTests/APICompatibilityFoundationModelsTests.swift
@@ -3,8 +3,18 @@ import Testing
 #if canImport(FoundationModels)
     import FoundationModels
 
+    private let isFoundationModelsSystemLanguageModelAvailable: Bool = {
+        if #available(macOS 26.0, *) {
+            return SystemLanguageModel.default.isAvailable
+        }
+        return false
+    }()
+
     @available(macOS 26.0, *)
-    @Test("FoundationModels Drop-In Compatibility", .enabled(if: SystemLanguageModel.default.isAvailable))
+    @Test(
+        "FoundationModels Drop-In Compatibility",
+        .enabled(if: isFoundationModelsSystemLanguageModelAvailable)
+    )
     func foundationModelsCompatibility() async throws {
         let model = SystemLanguageModel.default
         let session = LanguageModelSession(


### PR DESCRIPTION
Before making these changes, the tests would crash when targeting my macOS 15 computer in Xcode 26.2.

<img width="2940" height="1838" alt="AnyLanguageModel - macOS Sequoia - Xcode 26 2 - Before Changes" src="https://github.com/user-attachments/assets/ce9b07e7-456b-45e7-b109-b2875b2b4a8d" />

After the changes, the tests are correctly skipped and the test suite passes.

<img width="2940" height="1838" alt="AnyLanguageModel - macOS Sequoia - Xcode 26 2 - After Changes" src="https://github.com/user-attachments/assets/07ef5719-7f50-4c6c-aec6-407bd1534d2e" />
