### PR TITLE
Restore instructions from transcript

### DIFF
--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -69,11 +69,12 @@ public final class LanguageModelSession: @unchecked Sendable {
     ) {
         self.model = model
         self.tools = tools
-        self.instructions = instructions
+        let resolvedInstructions = instructions ?? Self.instructions(from: transcript)
+        self.instructions = resolvedInstructions
 
         // Build transcript with instructions if provided and not already in transcript
         var finalTranscript = transcript
-        if let instructions = instructions {
+        if let instructions = resolvedInstructions {
             // Only add instructions if transcript doesn't already start with instructions
             let hasInstructions =
                 finalTranscript.first.map { entry in
@@ -95,6 +96,16 @@ public final class LanguageModelSession: @unchecked Sendable {
         }
 
         self.state = .init(.init(finalTranscript))
+    }
+
+    private static func instructions(from transcript: Transcript) -> Instructions? {
+        guard case .instructions(let instructions)? = transcript.first else { return nil }
+        guard instructions.segments.count == 1,
+            case .text(let text) = instructions.segments[0]
+        else {
+            return nil
+        }
+        return Instructions(content: text.content)
     }
 
     public func prewarm(promptPrefix: Prompt? = nil) {

--- a/Tests/AnyLanguageModelTests/TranscriptTests.swift
+++ b/Tests/AnyLanguageModelTests/TranscriptTests.swift
@@ -55,6 +55,24 @@ struct TranscriptTests {
         #expect(Transcript.Segment.image(image).id == "image-id")
     }
 
+    @Test func sessionRestoresInstructionsFromTranscript() throws {
+        let instructions = "First\n\nSecond trailing spaces   "
+        let transcript = Transcript(entries: [
+            .instructions(.init(
+                id: "instructions-id",
+                segments: [.text(.init(content: instructions))],
+                toolDefinitions: []
+            )),
+            .prompt(.init(segments: [.text(.init(content: "Hello"))]))
+        ])
+
+        let session = LanguageModelSession(model: MockLanguageModel(), transcript: transcript)
+
+        #expect(session.instructions?.description == instructions)
+        #expect(session.transcript.count == transcript.count)
+        #expect(session.transcript.first?.id == "instructions-id")
+    }
+
     @Test func imageSourceRoundTripsForDataAndURL() throws {
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()


### PR DESCRIPTION
in order to 100% restore a session from a transcript (necessary to maintain cache for some models), the system instructions should be loaded from the transcript. Right now they are `nil` when using the `transcript` init of `LangaugeModelSession`.

- Restore session-level instructions when constructing a LanguageModelSession from a transcript with a leading instructions entry
- Recover the instruction text directly from the single text segment emitted by LanguageModelSession, preserving it byte-for-byte
- Add one focused regression test for transcript-based instruction restoration