### PR TITLE
Attempt to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - macos: "15"
-            swift: "6.1"
-            xcode: "16.3"
-            traits: ""
-          - macos: "15"
-            swift: "6.1"
-            xcode: "16.3"
-            traits: "AsyncHTTPClient"
+# Temporarily remove Swift 6.1 because mlx-swift-lm 3 uses Swift 6 mode and there's 
+# a strict concurrency error on a non-sendable CIContext.
+#          - macos: "15"
+#            swift: "6.1"
+#            xcode: "16.3"
+#            traits: ""
+#          - macos: "15"
+#            swift: "6.1"
+#            xcode: "16.3"
+#            traits: "AsyncHTTPClient"
           - macos: "26"
             swift: "6.2"
             xcode: "26.0"

--- a/Sources/AnyLanguageModel/Extensions/HTTPClient+Extensions.swift
+++ b/Sources/AnyLanguageModel/Extensions/HTTPClient+Extensions.swift
@@ -13,7 +13,6 @@
     import Foundation
     import NIOCore
     import NIOHTTP1
-    import NIOFoundationCompat
 
     extension HTTPClient {
         func fetch<T: Decodable>(
@@ -32,21 +31,21 @@
             }
 
             if let body {
-                request.body = .bytes(ByteBuffer(data: body))
+                request.body = .bytes(ByteBuffer(bytes: body))
                 request.headers.add(name: "Content-Type", value: "application/json")
             }
 
             let response = try await self.execute(request, timeout: .seconds(180))
 
             guard (200 ..< 300).contains(response.status.code) else {
-                let bodyData = try await Data(buffer: response.body.collect(upTo: 1024 * 1024))
+                let bodyData = try await Data(response.body.collect(upTo: 1024 * 1024).readableBytesView)
                 if let errorString = String(data: bodyData, encoding: .utf8) {
                     throw HTTPClientError.httpError(statusCode: Int(response.status.code), detail: errorString)
                 }
                 throw HTTPClientError.httpError(statusCode: Int(response.status.code), detail: "Invalid response")
             }
 
-            let bodyData = try await Data(buffer: response.body.collect(upTo: 1024 * 1024))
+            let bodyData = try await Data(response.body.collect(upTo: 1024 * 1024).readableBytesView)
 
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = dateDecodingStrategy
@@ -80,14 +79,14 @@
                         }
 
                         if let body {
-                            request.body = .bytes(ByteBuffer(data: body))
+                            request.body = .bytes(ByteBuffer(bytes: body))
                             request.headers.add(name: "Content-Type", value: "application/json")
                         }
 
                         let response = try await self.execute(request, timeout: .seconds(60))
 
                         guard (200 ..< 300).contains(response.status.code) else {
-                            let bodyData = try await Data(buffer: response.body.collect(upTo: 1024 * 1024))
+                            let bodyData = try await Data(response.body.collect(upTo: 1024 * 1024).readableBytesView)
                             if let errorString = String(data: bodyData, encoding: .utf8) {
                                 throw HTTPClientError.httpError(
                                     statusCode: Int(response.status.code),
@@ -149,14 +148,14 @@
                         }
 
                         if let body {
-                            request.body = .bytes(ByteBuffer(data: body))
+                            request.body = .bytes(ByteBuffer(bytes: body))
                             request.headers.add(name: "Content-Type", value: "application/json")
                         }
 
                         let response = try await self.execute(request, timeout: .seconds(60))
 
                         guard (200 ..< 300).contains(response.status.code) else {
-                            let bodyData = try await Data(buffer: response.body.collect(upTo: 1024 * 1024))
+                            let bodyData = try await Data(response.body.collect(upTo: 1024 * 1024).readableBytesView)
                             if let errorString = String(data: bodyData, encoding: .utf8) {
                                 throw HTTPClientError.httpError(
                                     statusCode: Int(response.status.code),


### PR DESCRIPTION
Broken in #161 

## Temporarily remove Swift 6.1 from the CI matrix.

`mlx-swift-lm` 3.x upgraded the Swift version, which fails to compile with
strict concurrency for SDKs earlier than 26.

An alternative would be to test the "MLX" trait separately on just Xcode
26, and keep the full matrix for the rest of traits.

## Use NIOCore to restore Linux compatibility.

Graph resolution changed after the bump to mlx-swift-lm 3 and
it looks like NIOFoundationCompat is no longer there.
